### PR TITLE
直近のしきい日を生成する

### DIFF
--- a/app/src/main/java/jp/idenon/dailyevent/DailyEventController.kt
+++ b/app/src/main/java/jp/idenon/dailyevent/DailyEventController.kt
@@ -39,13 +39,13 @@ class DailyEventController(val thresholdHour: Int, val thresholdMinute: Int) {
         var thresholdTime = currentTime
 
         val currentDate = currentTime.get(Calendar.DATE)
-        val currentHour = currentTime.get(Calendar.HOUR)
+        val currentHour = currentTime.get(Calendar.HOUR_OF_DAY)
         val currentMinute = currentTime.get(Calendar.MINUTE)
 
         if (currentHour < thresholdHour) {
-            thresholdTime.set(Calendar.DATE, currentDate - 1)
+            thresholdTime.add(Calendar.DAY_OF_MONTH, -1)
         }
-        thresholdTime.set(Calendar.HOUR, thresholdHour)
+        thresholdTime.set(Calendar.HOUR_OF_DAY, thresholdHour)
 
         thresholdTime.set(Calendar.MINUTE, thresholdMinute)
 

--- a/app/src/main/java/jp/idenon/dailyevent/DailyEventController.kt
+++ b/app/src/main/java/jp/idenon/dailyevent/DailyEventController.kt
@@ -34,4 +34,22 @@ class DailyEventController(val thresholdHour: Int, val thresholdMinute: Int) {
         isDone = true
     }
 
+    // 現在時刻の直前のリセット時刻を作る
+    fun calculateThresoldDate(thresholdHour: Int, thresholdMinute: Int, currentTime: Calendar){
+        var thresholdTime = currentTime
+
+        val currentHour = currentTime.get(Calendar.HOUR)
+        val currentMinute = currentTime.get(Calendar.MINUTE)
+
+        if (currentTime.get(Calendar.HOUR) > thresholdHour) {
+            thresholdHour.set(Calendar.HOUR, currentHour)
+        }
+
+    }
+
+    // 前回実行時間がリセット時刻より前にあるかどうかを返す
+    fun isBeforeResetTime(){
+
+    }
+
 }

--- a/app/src/main/java/jp/idenon/dailyevent/DailyEventController.kt
+++ b/app/src/main/java/jp/idenon/dailyevent/DailyEventController.kt
@@ -35,20 +35,25 @@ class DailyEventController(val thresholdHour: Int, val thresholdMinute: Int) {
     }
 
     // 現在時刻の直前のリセット時刻を作る
-    fun calculateThresoldDate(thresholdHour: Int, thresholdMinute: Int, currentTime: Calendar){
+    fun calculateThresoldDate(thresholdHour: Int, thresholdMinute: Int, currentTime: Calendar): Calendar {
         var thresholdTime = currentTime
 
+        val currentDate = currentTime.get(Calendar.DATE)
         val currentHour = currentTime.get(Calendar.HOUR)
         val currentMinute = currentTime.get(Calendar.MINUTE)
 
-        if (currentTime.get(Calendar.HOUR) > thresholdHour) {
-            thresholdHour.set(Calendar.HOUR, currentHour)
+        if (currentHour < thresholdHour) {
+            thresholdTime.set(Calendar.DATE, currentDate - 1)
         }
+        thresholdTime.set(Calendar.HOUR, thresholdHour)
 
+        thresholdTime.set(Calendar.MINUTE, thresholdMinute)
+
+        return thresholdTime
     }
 
     // 前回実行時間がリセット時刻より前にあるかどうかを返す
-    fun isBeforeResetTime(){
+    fun isBeforeResetTime() {
 
     }
 

--- a/app/src/test/java/jp/idenon/dailyevent/DailyEventControllerTest.kt
+++ b/app/src/test/java/jp/idenon/dailyevent/DailyEventControllerTest.kt
@@ -11,13 +11,36 @@ class DailyEventControllerTest {
         val dailyEvent = DailyEventController(5, 0)
 
         // 現在時刻は 2019/06/03 12:00
-        val currentDate = setCalender(2019, 6, 3, 12, 0)
-        // しきい値は 05:00
-        val thresholdDate = dailyEvent.calculateThresoldDate(5, 0, currentDate)
+        var currentDate = setCalender(2019, 6, 3, 12, 0)
+
+        // しきい値を 05:00 とする
+        var thresholdDate = dailyEvent.calculateThresoldDate(5, 0, currentDate)
 
         assertEquals(thresholdDate.get(Calendar.DATE), 3)
-        assertEquals(thresholdDate.get(Calendar.HOUR), 5)
+        assertEquals(thresholdDate.get(Calendar.HOUR_OF_DAY), 5)
         assertEquals(thresholdDate.get(Calendar.MINUTE), 0)
+
+        // しきい値を 17:00 とする
+        thresholdDate = dailyEvent.calculateThresoldDate(14, 0, currentDate)
+
+        assertEquals(thresholdDate.get(Calendar.DATE), 2)
+        assertEquals(thresholdDate.get(Calendar.HOUR_OF_DAY), 14)
+        assertEquals(thresholdDate.get(Calendar.MINUTE), 0)
+
+
+        // 現在時刻を 2019/01/01 00:00 に変える
+        // 年の境界テスト
+        currentDate = setCalender(2019, 0, 1, 0, 0)
+
+        // しきい値を 05:00 とする
+        val thresholdDate2 = dailyEvent.calculateThresoldDate(5, 0, currentDate)
+
+        assertEquals(thresholdDate2.get(Calendar.YEAR), 2018)
+        assertEquals(thresholdDate2.get(Calendar.MONTH) ,11)
+        assertEquals(thresholdDate2.get(Calendar.DATE), 31)
+        assertEquals(thresholdDate2.get(Calendar.HOUR_OF_DAY), 5)
+        assertEquals(thresholdDate2.get(Calendar.MINUTE), 0)
+
     }
 
     private fun setCalender(year: Int, month: Int, day: Int, hour: Int, minute: Int): Calendar {
@@ -26,7 +49,7 @@ class DailyEventControllerTest {
         date.set(Calendar.YEAR, year)
         date.set(Calendar.MONTH, month)
         date.set(Calendar.DATE, day)
-        date.set(Calendar.HOUR, hour)
+        date.set(Calendar.HOUR_OF_DAY, hour)
         date.set(Calendar.MINUTE, minute)
 
         return date

--- a/app/src/test/java/jp/idenon/dailyevent/DailyEventControllerTest.kt
+++ b/app/src/test/java/jp/idenon/dailyevent/DailyEventControllerTest.kt
@@ -1,10 +1,34 @@
 package jp.idenon.dailyevent
 
+import junit.framework.TestCase.assertEquals
 import org.junit.Test
+import java.util.*
 
-class DailyEventControllerTest() {
+class DailyEventControllerTest {
     @Test
-    fun calculateThresoldDateTest() {
+    fun calculateThresholdDateTest() {
 
+        val dailyEvent = DailyEventController(5, 0)
+
+        // 現在時刻は 2019/06/03 12:00
+        val currentDate = setCalender(2019, 6, 3, 12, 0)
+        // しきい値は 05:00
+        val thresholdDate = dailyEvent.calculateThresoldDate(5, 0, currentDate)
+
+        assertEquals(thresholdDate.get(Calendar.DATE), 3)
+        assertEquals(thresholdDate.get(Calendar.HOUR), 5)
+        assertEquals(thresholdDate.get(Calendar.MINUTE), 0)
+    }
+
+    private fun setCalender(year: Int, month: Int, day: Int, hour: Int, minute: Int): Calendar {
+        val date = Calendar.getInstance()
+
+        date.set(Calendar.YEAR, year)
+        date.set(Calendar.MONTH, month)
+        date.set(Calendar.DATE, day)
+        date.set(Calendar.HOUR, hour)
+        date.set(Calendar.MINUTE, minute)
+
+        return date
     }
 }

--- a/app/src/test/java/jp/idenon/dailyevent/DailyEventControllerTest.kt
+++ b/app/src/test/java/jp/idenon/dailyevent/DailyEventControllerTest.kt
@@ -1,0 +1,10 @@
+package jp.idenon.dailyevent
+
+import org.junit.Test
+
+class DailyEventControllerTest() {
+    @Test
+    fun calculateThresoldDateTest() {
+
+    }
+}


### PR DESCRIPTION
得られた現在時刻から、直近のしきい日（しきい値として設定された時・分を持つ、最も近い過去の日時）を生成できるようにしました。